### PR TITLE
Add maven 'profile id' and add intellij into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /.classpath
 /.project
 /bin/
+/.idea
+/*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
 	</properties>
 	<profiles>
 		<profile>
+			<id>windows</id>
 			<activation>
 				<os>
 					<family>Windows</family>
@@ -51,6 +52,7 @@
 			</dependencies>
 		</profile>
 		<profile>
+			<id>linux</id>
 			<activation>
 				<os>
 					<family>Linux</family>
@@ -66,6 +68,7 @@
 			</dependencies>
 		</profile>
 		<profile>
+			<id>mac</id>
 			<activation>
 				<os>
 					<family>Mac</family>


### PR DESCRIPTION
Maven needs profile id to compile.

Thx for the demo.